### PR TITLE
Fix warning for JS Date construction

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -88,7 +88,7 @@ class Calendar extends Component {
     showEventIndicators: false,
     startDate: moment().format('YYYY-MM-DD'),
     titleFormat: 'MMMM YYYY',
-    today: moment(),
+    today: moment().format('YYYY-MM-DD'),
     weekStart: 1,
     rangeEnabled: false,
     fadedRange: false,


### PR DESCRIPTION
Fixed JS Date Construction issue: http://momentjs.com/guides/#/warnings/js-date/

![screen shot 2017-04-20 at 12 25 56 am](https://cloud.githubusercontent.com/assets/9297599/25218448/bede2e76-255f-11e7-9489-78ae76605617.png)
